### PR TITLE
SLT-276: Delete pvcs when deleting releases.

### DIFF
--- a/delete-deployment.sh
+++ b/delete-deployment.sh
@@ -16,3 +16,6 @@ helm delete --purge $RELEASE_NAME
 
 # Remove jobs
 kubectl delete job -l release=$RELEASE_NAME -n $NAMESPACE
+
+# Remove PersistentVolumeClaim left over from StatefulSets
+kubectl delete pvc -l release=$RELEASE_NAME -n $NAMESPACE


### PR DESCRIPTION
Currently, when a StatefulSet is deleted, the associated PersistentVolumeClaims remain. This concretely means that when a release of the Drupal chart is deleted, the mariadb volumes are kept indefinitely, which causes unnecessary storage cost.