### PR TITLE
Execute deletion script asynchronously.

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,15 +70,17 @@ queue.process('remover', function (job, done){
   process.env.RELEASE_NAME = release_name;
   
   // Log on to cluster and remove helm deployment
-  try {
-    const output = child_process.execSync('/app/delete-deployment.sh');
-    console.log(output.toString());
-  } 
-  catch (err) {
-    console.log('ERROR:', err)
-  }
-  
-  done();
+  child_process.exec('/app/delete-deployment.sh', function (error, stdout, stderr) {
+    console.log(stdout);
+    if (error) {
+      console.log('ERROR:', stderr);
+      done(error);
+    }
+    else {
+      done();
+      console.log(output.toString());
+    }
+  });
 });
 
 // Adds branch removal job to remover queue


### PR DESCRIPTION
There are still Github webhook calls that fail occasionally, leaving unwanted Helm releases behind. I think this might be due to the fact that the deletion script is executed synchronously, which blocks the web server endpoint from responding to additional calls. I also realized that we never mark the Kue job as failed, so although we specify `attempt(5)` the script would never retry after a failure.