### PR TITLE
SLT-412: Also delete Elasticsearch PVCs.

### DIFF
--- a/delete-deployment.sh
+++ b/delete-deployment.sh
@@ -25,3 +25,6 @@ kubectl delete job -l release=$RELEASE_NAME -n $NAMESPACE
 
 # Remove PersistentVolumeClaim left over from StatefulSets
 kubectl delete pvc -l release=$RELEASE_NAME -n $NAMESPACE
+
+# Also remove PersistentVolumeClaims from Elasticsearch, that chart has different labels.
+kubectl delete pvc -l app="${RELEASE_NAME}-es" -n $NAMESPACE


### PR DESCRIPTION
We ended up with a lot of leftover pvcs, which were actually using a substantial amount of storage. I removed those, here's a fix to remove them right away automatically.