### PR TITLE
Add the missing jq binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine
 
-RUN apk add curl bash python
+RUN apk add curl bash python jq
 
 # Add gcloud CLI
 RUN curl -sSL https://sdk.cloud.google.com | bash \


### PR DESCRIPTION
I was investigating why branches from a certain project were not getting deleted. The logic based on the branch name metadata is sound, only the helper `jq` binary is missing. This should fix it :-)