### PR TITLE
Remove pvc based on helm instance label

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -157,10 +157,31 @@ func removeRelease(namespace string, branchName string) {
 				}
 			}
 
-			// Find PVC's by release name label
 			PVC_client := clientset.CoreV1().PersistentVolumeClaims(namespace)
+
+			// Find PVC's by release name label
 			list, err := PVC_client.List(context.TODO(), metav1.ListOptions{
 				LabelSelector: "release=" + releaseName,
+			})
+			if err != nil {
+				log.Fatalf("Error getting the list of PVCs: %s", err)
+			}
+
+			// Iterate pvc's
+			for _, v := range list.Items {
+				log.Printf("PVC name: %s", v.Name)
+				if debug {
+					log.Println("  Debug mode, not removing PVC")
+				} else {
+					// Delete PVC's
+					PVC_client.Delete(context.TODO(), v.Name, metav1.DeleteOptions{})
+					log.Println("  PVC deleted:", v.Name)
+				}
+			}
+
+			// Find PVC's by app.kubernetes.io/instance label
+			list, err = PVC_client.List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "app.kubernetes.io/instance=" + releaseName,
 			})
 			if err != nil {
 				log.Fatalf("Error getting the list of PVCs: %s", err)

--- a/app/main.go
+++ b/app/main.go
@@ -160,6 +160,7 @@ func removeRelease(namespace string, branchName string) {
 			PVC_client := clientset.CoreV1().PersistentVolumeClaims(namespace)
 
 			selectorLabels := []string{
+				"app",
 				"release",
 				"app.kubernetes.io/instance",
 			}
@@ -167,8 +168,14 @@ func removeRelease(namespace string, branchName string) {
 			for _, l := range selectorLabels {
 
 				// Find PVC's by release name label
+
+				selector := l + "=" + releaseName
+				if l == "app" {
+					selector = l + "=" + releaseName + "-es"
+				}
+
 				list, err := PVC_client.List(context.TODO(), metav1.ListOptions{
-					LabelSelector: l + "=" + releaseName,
+					LabelSelector: selector,
 				})
 				if err != nil {
 					log.Fatalf("Error getting the list of PVCs: %s", err)

--- a/app/main.go
+++ b/app/main.go
@@ -159,43 +159,31 @@ func removeRelease(namespace string, branchName string) {
 
 			PVC_client := clientset.CoreV1().PersistentVolumeClaims(namespace)
 
-			// Find PVC's by release name label
-			list, err := PVC_client.List(context.TODO(), metav1.ListOptions{
-				LabelSelector: "release=" + releaseName,
-			})
-			if err != nil {
-				log.Fatalf("Error getting the list of PVCs: %s", err)
+			selectorLabels := []string{
+				"release",
+				"app.kubernetes.io/instance",
 			}
 
-			// Iterate pvc's
-			for _, v := range list.Items {
-				log.Printf("PVC name: %s", v.Name)
-				if debug {
-					log.Println("  Debug mode, not removing PVC")
-				} else {
-					// Delete PVC's
-					PVC_client.Delete(context.TODO(), v.Name, metav1.DeleteOptions{})
-					log.Println("  PVC deleted:", v.Name)
+			for _, l := range selectorLabels {
+
+				// Find PVC's by release name label
+				list, err := PVC_client.List(context.TODO(), metav1.ListOptions{
+					LabelSelector: l + "=" + releaseName,
+				})
+				if err != nil {
+					log.Fatalf("Error getting the list of PVCs: %s", err)
 				}
-			}
 
-			// Find PVC's by app.kubernetes.io/instance label
-			list, err = PVC_client.List(context.TODO(), metav1.ListOptions{
-				LabelSelector: "app.kubernetes.io/instance=" + releaseName,
-			})
-			if err != nil {
-				log.Fatalf("Error getting the list of PVCs: %s", err)
-			}
-
-			// Iterate pvc's
-			for _, v := range list.Items {
-				log.Printf("PVC name: %s", v.Name)
-				if debug {
-					log.Println("  Debug mode, not removing PVC")
-				} else {
-					// Delete PVC's
-					PVC_client.Delete(context.TODO(), v.Name, metav1.DeleteOptions{})
-					log.Println("  PVC deleted:", v.Name)
+				// Iterate pvc's
+				for _, v := range list.Items {
+					log.Printf("PVC name: %s", v.Name)
+					if debug {
+						log.Println("  Debug mode, not removing PVC")
+					} else {
+						// Delete PVC's
+						PVC_client.Delete(context.TODO(), v.Name, metav1.DeleteOptions{})
+						log.Println("  PVC deleted:", v.Name)
+					}
 				}
 			}
 


### PR DESCRIPTION
Remove pvc based on helm instance label

Whoever merges this, has to build and push image manually as builder integration is removed now. Requires 3 tags - `v0.2.1` (if it's still unused), `v0.2` and `latest`.
See list of tags: https://hub.docker.com/r/wunderio/silta-deployment-remover/tags